### PR TITLE
Remove `plugin.name`

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@ const CronAllowedRange = require('cron-allowed-range');
 
 module.exports = function(config) {
   return {
-    name: 'deployment-hours',
     onInit: ({ utils }) => {
       const expression = process.env.DEPLOYMENT_HOURS_EXPRESSION || '* * * * *';
       const timezone = process.env.DEPLOYMENT_HOURS_TIMEZONE || 'America/Toronto';


### PR DESCRIPTION
The `plugin` `name` property has been removed in favor of [`manifest.yml`](https://github.com/netlify/build#anatomy-of-a-plugin).