### PR TITLE
Remove top-level function

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 const CronAllowedRange = require('cron-allowed-range');
 
-module.exports = function(config) {
-  return {
+module.exports = {
     name: 'deployment-hours',
     onInit: ({ utils }) => {
       const expression = process.env.DEPLOYMENT_HOURS_EXPRESSION || '* * * * *';
@@ -16,5 +15,4 @@ module.exports = function(config) {
         utils.build.failBuild('Deployment not allowed at this time.');
       }
     }
-  }
 };


### PR DESCRIPTION
The plugin top-level function is unused here, and can be removed to simplify the code.