### PR TITLE
Add `manifest.yml` and `inputs`

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ version](https://badge.fury.io/js/netlify-deployment-hours-plugin.svg)](https://
 
 # netlify-deployment-hours-plugin
 
-A Netlify build plugin that blocks deployment if it is outside of deployment hours.
+A Netlify build plugin that blocks deployment if it is outside of deployment
+hours.
 
 ## Usage
 
@@ -15,7 +16,8 @@ To install, add the following lines to your `netlify.toml` file:
 package = "netlify-deployment-hours-plugin"
 ```
 
-Note: The `[[plugins]]` line is required for each plugin, even if you have other plugins in your `netlify.toml` file already.
+Note: The `[[plugins]]` line is required for each plugin, even if you have other
+plugins in your `netlify.toml` file already.
 
 There are two `inputs` used to configure this plugin:
 
@@ -35,3 +37,11 @@ Both are passed into
 determine if a deployment should proceed. See the [`cron-allowed-range`
 documentation](https://github.com/neverendingqs/cron-allowed-range) for more
 details on how to form the cron-like expression.
+
+The `inputs` can be overridden with environment variables for scenarios where
+emergency deploys were required outside of regular deployment hours:
+
+```
+* `DEPLOYMENT_HOURS_EXPRESSION`
+* `DEPLOYMENT_HOURS_TIMEZONE`
+```

--- a/README.md
+++ b/README.md
@@ -17,12 +17,18 @@ package = "netlify-deployment-hours-plugin"
 
 Note: The `[[plugins]]` line is required for each plugin, even if you have other plugins in your `netlify.toml` file already.
 
-There are two environment variable used to configure this plugin:
+There are two `inputs` used to configure this plugin:
 
-* `DEPLOYMENT_HOURS_EXPRESSION`
-  * A cron-like expression that expresses when a deployment can occur
-* `DEPLOYMENT_HOURS_TIMEZONE`
-  * tz database value that expresses the timezone of the expression
+```toml
+[[plugins]]
+package = "netlify-deployment-hours-plugin"
+
+  [plugins.inputs]
+  # A cron-like expression that expresses when a deployment can occur
+  expression = "* * * * *"
+  # tz database value that expresses the timezone of the expression
+  timezone = "America/Toronto"
+```
 
 Both are passed into
 [cron-allowed-range](https://github.com/neverendingqs/cron-allowed-range) to

--- a/index.js
+++ b/index.js
@@ -1,6 +1,10 @@
 const CronAllowedRange = require('cron-allowed-range');
+
 module.exports = {
-    onPreBuild: ({ utils, inputs: { expression, timezone } }) => {
+    onPreBuild: ({ utils, inputs }) => {
+      const expression = inputs.env || process.env.DEPLOYMENT_HOURS_EXPRESSION || '* * * * *';
+      const timezone = inputs.env || process.env.DEPLOYMENT_HOURS_TIMEZONE || 'America/Toronto';
+
       const cr = getCronAllowedRange(expression, timezone, utils);
       const now = new Date();
 

--- a/index.js
+++ b/index.js
@@ -1,9 +1,35 @@
 const CronAllowedRange = require('cron-allowed-range');
 
+function getConfigValue({ configName, defaultValue, env, input }) {
+  if(env) {
+    console.log(`Using '${configName}=${env}' (from environment variable)`);
+    return env;
+  }
+
+  if(input) {
+    console.log(`Using '${configName}=${input}' (from manifest file)`);
+    return input;
+  }
+
+  console.log(`Using '${configName}=${defaultValue}' (default value)`);
+  return defaultValue;
+}
+
 module.exports = {
     onPreBuild: ({ utils, inputs }) => {
-      const expression = inputs.env || process.env.DEPLOYMENT_HOURS_EXPRESSION || '* * * * *';
-      const timezone = inputs.env || process.env.DEPLOYMENT_HOURS_TIMEZONE || 'America/Toronto';
+      const expression = getConfigValue({
+        configName: 'expression',
+        defaultValue: '* * * * *',
+        env: process.env.DEPLOYMENT_HOURS_EXPRESSION,
+        input: inputs.expression
+      });
+
+      const timezone = getConfigValue({
+        configName: 'timezone',
+        defaultValue: 'America/Toronto',
+        env: process.env.DEPLOYMENT_HOURS_TIMEZONE,
+        input: inputs.timezone
+      });
 
       const cr = getCronAllowedRange(expression, timezone, utils);
       const now = new Date();

--- a/index.js
+++ b/index.js
@@ -3,10 +3,7 @@ const CronAllowedRange = require('cron-allowed-range');
 module.exports = function(config) {
   return {
     name: 'deployment-hours',
-    onInit: ({ utils }) => {
-      const expression = process.env.DEPLOYMENT_HOURS_EXPRESSION || '* * * * *';
-      const timezone = process.env.DEPLOYMENT_HOURS_TIMEZONE || 'America/Toronto';
-
+    onInit: ({ utils, inputs: { expression, timezone } }) => {
       const cr = new CronAllowedRange(expression, timezone);
       const now = new Date();
 

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,8 +1,6 @@
 name: netlify-deployment-hours-plugin
 inputs:
   - name: expression
-    default: '* * * * *'
     description: A cron-like expression that expresses when a deployment can occur
   - name: timezone
-    default: America/Toronto
     description: tz database value that expresses the timezone of the expression

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,6 +1,6 @@
 name: netlify-deployment-hours-plugin
 inputs:
   - name: expression
-    description: A cron-like expression that expresses when a deployment can occur
+    description: A cron-like expression that expresses when a deployment can occur. Can be overridden with environment variable DEPLOYMENT_HOURS_EXPRESSION.
   - name: timezone
-    description: tz database value that expresses the timezone of the expression
+    description: tz database value that expresses the timezone of the expression. Can be overriden with environment variable DEPLOYMENT_HOURS_TIMEZONE.

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,8 @@
+name: netlify-deployments-hours-plugin
+inputs:
+  - name: expression
+    default: '* * * * *'
+    description: A cron-like expression that expresses when a deployment can occur
+  - name: timezone
+    default: America/Toronto
+    description: tz database value that expresses the timezone of the expression


### PR DESCRIPTION
The latest version of Netlify Build introduces two new concepts:
  - a `manifest.yml` that declares metadata about your plugin. For the moment, it is just the plugin `name` and `inputs`
  - `inputs` now replace `config`/`pluginConfig`. They can have a `description`, a `default` value and be marked as `required`. We are working on making those editable through the Netlify App UI so users don't have to set environment variables.

This PR updates the plugin to those. Note that this replaces environment variable configuration to `inputs` instead, so this would be a breaking change. Feel free to discard that change if you'd prefer to use environment variables :)