### PR TITLE
Improve error handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ module.exports = function(config) {
       const expression = process.env.DEPLOYMENT_HOURS_EXPRESSION || '* * * * *';
       const timezone = process.env.DEPLOYMENT_HOURS_TIMEZONE || 'America/Toronto';
 
-      const cr = new CronAllowedRange(expression, timezone);
+      const cr = getCronAllowedRange(expression, timezone, utils);
       const now = new Date();
 
       console.log(`Current time: '${now}'. Expression: '${expression}'. Timezone: '${timezone}'.`);
@@ -16,5 +16,13 @@ module.exports = function(config) {
         utils.build.failBuild('Deployment not allowed at this time.');
       }
     }
+  }
+};
+
+const getCronAllowedRange = function(expression, timezone, utils) {
+  try {
+    return new CronAllowedRange(expression, timezone);
+  } catch (error) {
+    utils.build.failPlugin('Invalid Cron expression or timezone', { error })
   }
 };


### PR DESCRIPTION
When users input an invalid cron `expression` or `timezone`, the `utils.build.failPlugin()` method should be used for improved error reporting.