### PR TITLE
Use `cancelBuild()`

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ module.exports = function(config) {
       console.log(`Current time: '${now}'. Expression: '${expression}'. Timezone: '${timezone}'.`);
 
       if(!cr.isDateAllowed(now)) {
-        utils.build.failBuild('Deployment not allowed at this time.');
+        utils.build.cancelBuild('Deployment not allowed at this time.');
       }
     }
   }


### PR DESCRIPTION
The new `utils.build.cancelBuild()` is now available to mark a build as canceled instead of failed. I think this might work better for this plugin: please let me know what you think! :)