### PR TITLE
Rename `onInit`

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const CronAllowedRange = require('cron-allowed-range');
 module.exports = function(config) {
   return {
     name: 'deployment-hours',
-    onInit: ({ utils }) => {
+    onPreBuild: ({ utils }) => {
       const expression = process.env.DEPLOYMENT_HOURS_EXPRESSION || '* * * * *';
       const timezone = process.env.DEPLOYMENT_HOURS_TIMEZONE || 'America/Toronto';
 


### PR DESCRIPTION
The `onInit` event handler has been renamed to `onPreBuild` since those two are currently identical. This PR renames this handler.