### PR TITLE
feat: added option to enforce restriction for only production deploys

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ package = "netlify-deployment-hours-plugin"
   expression = "* * * * *"
   # tz database value that expresses the timezone of the expression
   timezone = "America/Toronto"
+  # True or false value to indicate if the restrictions should apply to production deploys or all deploys
+  productionOnly = false
 ```
 
 Both are passed into
@@ -44,4 +46,5 @@ emergency deploys were required outside of regular deployment hours:
 ```
 * `DEPLOYMENT_HOURS_EXPRESSION`
 * `DEPLOYMENT_HOURS_TIMEZONE`
+* `DEPLOYMENT_HOURS_PRODUCTION_ONLY`
 ```

--- a/index.js
+++ b/index.js
@@ -17,28 +17,39 @@ function getConfigValue({ configName, defaultValue, env, input }) {
 
 module.exports = {
     onPreBuild: ({ utils, inputs }) => {
-      const expression = getConfigValue({
-        configName: 'expression',
-        defaultValue: '* * * * *',
-        env: process.env.DEPLOYMENT_HOURS_EXPRESSION,
-        input: inputs.expression
+
+      const productionOnly = getConfigValue({
+        configName: 'productionOnly',
+        defaultValue: false,
+        env: process.env.DEPLOYMENT_HOURS_PRODUCTION_ONLY,
+        input: inputs.productionOnly
       });
 
-      const timezone = getConfigValue({
-        configName: 'timezone',
-        defaultValue: 'America/Toronto',
-        env: process.env.DEPLOYMENT_HOURS_TIMEZONE,
-        input: inputs.timezone
-      });
+      if(productionOnly === false || (productionOnly === true && process.env.CONTEXT === 'production')){
+        const expression = getConfigValue({
+          configName: 'expression',
+          defaultValue: '* * * * *',
+          env: process.env.DEPLOYMENT_HOURS_EXPRESSION,
+          input: inputs.expression
+        });
 
-      const cr = getCronAllowedRange(expression, timezone, utils);
-      const now = new Date();
+        const timezone = getConfigValue({
+          configName: 'timezone',
+          defaultValue: 'America/Toronto',
+          env: process.env.DEPLOYMENT_HOURS_TIMEZONE,
+          input: inputs.timezone
+        });
 
-      console.log(`Current time: '${now}'. Expression: '${expression}'. Timezone: '${timezone}'.`);
+        const cr = getCronAllowedRange(expression, timezone, utils);
+        const now = new Date();
 
-      if(!cr.isDateAllowed(now)) {
-        utils.build.cancelBuild('Deployment not allowed at this time.');
+        console.log(`Current time: '${now}'. Expression: '${expression}'. Timezone: '${timezone}'.`);
+
+        if(!cr.isDateAllowed(now)) {
+          utils.build.cancelBuild('Deployment not allowed at this time.');
+        }
       }
+
     }
 };
 

--- a/manifest.yml
+++ b/manifest.yml
@@ -4,3 +4,5 @@ inputs:
     description: A cron-like expression that expresses when a deployment can occur. Can be overridden with environment variable DEPLOYMENT_HOURS_EXPRESSION.
   - name: timezone
     description: tz database value that expresses the timezone of the expression. Can be overriden with environment variable DEPLOYMENT_HOURS_TIMEZONE.
+  - name: productionOnly
+    description: True or false to indicate if the restrictions should apply to production deploys or all deploys. Can be overriden with environment variable DEPLOYMENT_HOURS_PRODUCTION_ONLY.


### PR DESCRIPTION
This changes supports my use-case where only production deploys need to be restricted. Original behaviour is still maintained as the additional input (`productionOnly`) defaults to false.